### PR TITLE
fix: add an error catch for deferrerd rows errors

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -31,6 +31,9 @@ func OneFromRows[T any](ctx context.Context, m Mapper[T], rows Rows) (T, error) 
 	before, after := m(ctx, v.columnsCopy())
 
 	if !rows.Next() {
+		if err = rows.Err(); err != nil {
+			return t, err
+		}
 		return t, sql.ErrNoRows
 	}
 


### PR DESCRIPTION
At the moment, insertion with unique constraint violation reporting `sql.ErrNoRows` after scanning. This change will report any error populated in rows.

Ref: https://github.com/jackc/pgx/issues/570