### PR TITLE
Pass allow unknown flag to row scanner.

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -77,9 +77,9 @@ func testQuery[T any](t *testing.T, name string, tc queryCase[T]) {
 	t.Helper()
 
 	t.Run(name, func(t *testing.T) {
-		ctx := context.Background()
-		if tc.ctx != nil {
-			ctx = tc.ctx
+		ctx := tc.ctx
+		if ctx == nil {
+			ctx = context.Background()
 		}
 
 		ex, clean := createDB(t, tc.columns)

--- a/exec_test.go
+++ b/exec_test.go
@@ -63,6 +63,7 @@ func createQuery(tb testing.TB, cols []string) string {
 }
 
 type queryCase[T any] struct {
+	ctx         context.Context
 	columns     strstr
 	rows        rows
 	query       []string // columns to select
@@ -77,6 +78,9 @@ func testQuery[T any](t *testing.T, name string, tc queryCase[T]) {
 
 	t.Run(name, func(t *testing.T) {
 		ctx := context.Background()
+		if tc.ctx != nil {
+			ctx = tc.ctx
+		}
 
 		ex, clean := createDB(t, tc.columns)
 		defer clean()
@@ -281,5 +285,32 @@ func TestStruct(t *testing.T) {
 			{User: user1, Timestamps: timestamp1},
 			{User: user2, Timestamps: timestamp2},
 		},
+	})
+}
+
+func TestAllowUnknownColumns(t *testing.T) {
+	type testStruct struct {
+		ID  int64
+		Int int64
+	}
+
+	// fails when context does not have CtxKeyAllowUnknownColumns set to true
+	testQuery(t, "unknowncolumnsnotallowed", queryCase[testStruct]{
+		columns:     strstr{{"id", "int64"}, {"ignored_int", "int64"}, {"int", "int64"}},
+		rows:        rows{{1, 10, 1}, {2, 20, 2}},
+		query:       []string{"id", "ignored_int", "int"},
+		mapper:      StructMapper[testStruct](),
+		expectedErr: createError(fmt.Errorf("No destination for column ignored_int"), "no destination", "ignored_int"),
+	})
+
+	// succeeds when context has CtxKeyAllowUnknownColumns set to true
+	testQuery(t, "unknowncolumnsallowed", queryCase[testStruct]{
+		ctx:       context.WithValue(context.Background(), CtxKeyAllowUnknownColumns, true),
+		columns:   strstr{{"id", "int64"}, {"ignored_int", "int64"}, {"int", "int64"}},
+		rows:      rows{{1, 10, 1}, {2, 20, 2}},
+		query:     []string{"id", "ignored_int", "int"},
+		mapper:    StructMapper[testStruct](),
+		expectOne: testStruct{ID: 1, Int: 1},
+		expectAll: []testStruct{{ID: 1, Int: 1}, {ID: 2, Int: 2}},
 	})
 }

--- a/row.go
+++ b/row.go
@@ -65,7 +65,22 @@ func (r *Row) scanCurrentRow() error {
 		return createError(fmt.Errorf("unknown columns to map to: %v", r.unknownDestinations), r.unknownDestinations...)
 	}
 
-	targets := makeTargets(len(r.columns))
+	targets, err := r.createTargets()
+	if err != nil {
+		return err
+	}
+
+	err = r.r.Scan(targets...)
+	if err != nil {
+		return err
+	}
+
+	r.scanDestinations = make([]reflect.Value, len(r.columns))
+	return nil
+}
+
+func (r *Row) createTargets() ([]any, error) {
+	targets := make([]any, len(r.columns))
 
 	for i, name := range r.columns {
 		dest := r.scanDestinations[i]
@@ -76,26 +91,14 @@ func (r *Row) scanCurrentRow() error {
 
 		if !r.allowUnknown {
 			err := fmt.Errorf("No destination for column %s", name)
-			return createError(err, "no destination", name)
+			return nil, createError(err, "no destination", name)
 		}
-	}
 
-	err := r.r.Scan(targets...)
-	if err != nil {
-		return err
-	}
-
-	r.scanDestinations = make([]reflect.Value, len(r.columns))
-	return nil
-}
-
-// See https://github.com/golang/go/issues/41607:
-// Some drivers cannot work with nil values, so valid pointers should be
-// used for all column targets, even if they are discarded afterwards.
-func makeTargets(length int) []any {
-	targets := make([]any, length)
-	for i := range targets {
+		// See https://github.com/golang/go/issues/41607:
+		// Some drivers cannot work with nil values, so valid pointers should be
+		// used for all column targets, even if they are discarded afterwards.
 		targets[i] = new(interface{})
 	}
-	return targets
+
+	return targets, nil
 }


### PR DESCRIPTION
- Pass the flag to row scanner
- Add test
- Extra: initialize row scanner targets array with valid pointers,
              because it is not guaranteed that all drivers support scanning into nil
              (golang's `database/sql` does not for example).