### PR TITLE
perf: reuse per-row scan buffers in Row

### DIFF
--- a/row.go
+++ b/row.go
@@ -17,6 +17,7 @@ func wrapRows(r Rows, allowUnknown bool) (*Row, error) {
 		r:                r,
 		columns:          cols,
 		scanDestinations: make([]reflect.Value, len(cols)),
+		scanTargets:      make([]any, len(cols)),
 		allowUnknown:     allowUnknown,
 	}, nil
 }
@@ -32,6 +33,7 @@ type Row struct {
 	r                   Rows
 	columns             []string
 	scanDestinations    []reflect.Value
+	scanTargets         []any
 	unknownDestinations []string
 	allowUnknown        bool
 }
@@ -91,12 +93,17 @@ func (r *Row) scanCurrentRow() error {
 		return err
 	}
 
-	r.scanDestinations = make([]reflect.Value, len(r.columns))
+	// Reset scan destinations in place for the next row. The before hook
+	// re-populates the same indices deterministically, so zeroing is enough
+	// (go.mod is go 1.18, so no clear() builtin).
+	for i := range r.scanDestinations {
+		r.scanDestinations[i] = zeroValue
+	}
 	return nil
 }
 
 func (r *Row) createTargets() ([]any, error) {
-	targets := make([]any, len(r.columns))
+	targets := r.scanTargets
 
 	for i, name := range r.columns {
 		dest := r.scanDestinations[i]


### PR DESCRIPTION
## Summary

Eliminates two per-row allocations in `Row`'s scan path. `scanCurrentRow`
runs once per row for every mapper type (typed or reflection) and every
query, so this scales with row count × column width — preloads (parent +
all child columns) pay the most.

## Changes

- **`scanDestinations`**: was reallocated via `make()` every row just to
  reset state. The `before` hook re-populates the same indices
  deterministically, so we now zero it in place instead (manual loop —
  `go.mod` is go 1.18, no `clear()` builtin).
- **`scanTargets`**: `createTargets` allocated a fresh `[]any` per row for
  `rows.Scan(...)`. Drivers don't retain it past `Scan`, so it's now a
  Row-scoped buffer allocated once in `wrapRows` and refilled each row.

## Safety

`before(v) → scanCurrentRow → after(val)` is synchronous per row
(`scanOneRow` in exec.go), and columns are constant per query, so buffer
reuse and in-place zeroing are behavior-preserving. `createTargets`
overwrites every index each row, so no stale values leak between rows.

## Benchmarks

Wide-struct bench (11 columns, 100 rows), `-count=3`:

| Benchmark | Metric | Before | After | Δ |
|-----------|--------|--------|-------|---|
| `ScanAll` | allocs/op | 520 | 321 | **−38%** |
| `ScanAll` | B/op | 134,704 | 88,512 | −34% |
| `ScanAll` | ns/op | ~54,000 | ~48,250 | −11% |
| `ScanOne` | allocs/op | 16 | 15 | −1 |
| `ScanOne` | B/op | 2,808 | 2,552 | −9% |

All existing tests pass.