### PR TITLE
fix: check rows.Err() after iteration in Each to surface mid-stream e…

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -122,6 +122,10 @@ func Each[T any](ctx context.Context, exec Queryer, m Mapper[T], query string, a
 				return
 			}
 		}
+
+		if err := rows.Err(); err != nil {
+			yield(*new(T), err)
+		}
 	}
 }
 


### PR DESCRIPTION
`Each` silently drops database errors that occur during row iteration. Both `*sql.Rows` and `pgx.Rows` follow the contract that `Next()` can return false due to an error, with the actual error available via `Err()`. `OneFromRows` and `AllFromRows` both return `rows.Err()` after the loop, each was missing this check, causing mid-stream connection drops, context deadlines, or SQL errors from functions to be silently swallowed.