### PR TITLE
perf: build the struct mapping plan once per query, not once per row

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -244,6 +245,87 @@ type Wide45 struct {
 	Col42 string `db:"col_42"`
 	Col43 string `db:"col_43"`
 	Col44 string `db:"col_44"`
+}
+
+// benchConverter is a minimal pass-through TypeConverter: it scans into the
+// field's own type, so the benchmarks measure the allOptions machinery itself.
+type benchConverter struct{}
+
+func (benchConverter) TypeToDestination(t reflect.Type) reflect.Value { return reflect.New(t) }
+
+func (benchConverter) ValueFromDestination(v reflect.Value) reflect.Value { return v.Elem() }
+
+func benchValidator(cols []string, vals []reflect.Value) bool { return true }
+
+func BenchmarkScanWide15Converter(b *testing.B) {
+	benchmarkScanWideOpts[Wide15](b, "wide15", WithTypeConverter(benchConverter{}))
+}
+
+func BenchmarkScanWide45Converter(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45", WithTypeConverter(benchConverter{}))
+}
+
+func BenchmarkScanWide45Validator(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45", WithRowValidator(benchValidator))
+}
+
+func BenchmarkScanWide45ConverterValidator(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45",
+		WithTypeConverter(benchConverter{}), WithRowValidator(benchValidator))
+}
+
+// Wide15Nested spreads the 15 columns over two embedded pointer structs, so
+// every row initializes the mapping's nested-pointer init paths.
+type Wide15Nested struct {
+	*Wide15NestedA
+	*Wide15NestedB
+}
+
+type Wide15NestedA struct {
+	Col0 string `db:"col_0"`
+	Col1 string `db:"col_1"`
+	Col2 string `db:"col_2"`
+	Col3 string `db:"col_3"`
+	Col4 string `db:"col_4"`
+	Col5 string `db:"col_5"`
+	Col6 string `db:"col_6"`
+	Col7 string `db:"col_7"`
+}
+
+type Wide15NestedB struct {
+	Col8  string `db:"col_8"`
+	Col9  string `db:"col_9"`
+	Col10 string `db:"col_10"`
+	Col11 string `db:"col_11"`
+	Col12 string `db:"col_12"`
+	Col13 string `db:"col_13"`
+	Col14 string `db:"col_14"`
+}
+
+func BenchmarkScanWide15Nested(b *testing.B) {
+	benchmarkScanWide[Wide15Nested](b, "wide15")
+}
+
+func BenchmarkScanWide15NestedConverter(b *testing.B) {
+	benchmarkScanWideOpts[Wide15Nested](b, "wide15", WithTypeConverter(benchConverter{}))
+}
+
+func benchmarkScanWideOpts[T any](b *testing.B, table string, opts ...MappingOption) {
+	b.StopTimer()
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		rows, err := db.Query("SELECT|" + table + "||")
+		if err != nil {
+			panic(err)
+		}
+		b.StartTimer()
+		if _, err := AllFromRows(ctx, StructMapper[T](opts...), rows); err != nil {
+			panic(err)
+		}
+		rows.Close()
+	}
 }
 
 type Userss struct {

--- a/mapper_struct.go
+++ b/mapper_struct.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // CtxKeyAllowUnknownColumns makes it possible to allow unknown columns using the context
@@ -177,24 +178,26 @@ type regular[T any] struct {
 }
 
 func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
+	// The mapping is fixed for the duration of the query, so everything that
+	// only depends on it is resolved here, once, instead of once per row.
+	styp := s.typ
+	if s.isPointer {
+		styp = s.typ.Elem()
+	}
+	inits := uniqueInits(s.filtered)
+
 	return func(v *Row) (any, error) {
-			var row reflect.Value
-			if s.isPointer {
-				row = reflect.New(s.typ.Elem()).Elem()
-			} else {
-				row = reflect.New(s.typ).Elem()
+			row := reflect.New(styp).Elem()
+
+			// row is freshly zero, so each unique nested pointer is
+			// initialized exactly once, ancestors before descendants,
+			// before any field address is scheduled
+			for _, path := range inits {
+				pv := row.FieldByIndex(path)
+				pv.Set(reflect.New(pv.Type().Elem()))
 			}
 
 			for _, info := range s.filtered {
-				for _, v := range info.init {
-					pv := row.FieldByIndex(v)
-					if !pv.IsZero() {
-						continue
-					}
-
-					pv.Set(reflect.New(pv.Type().Elem()))
-				}
-
 				fv := row.FieldByIndex(info.position)
 				v.ScheduleScanByIndexX(info.colIndex, fv.Addr())
 			}
@@ -211,22 +214,55 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 		}
 }
 
+// uniqueInits collects the nested-pointer init paths of all filtered columns,
+// de-duplicated, preserving ancestor-before-descendant order.
+func uniqueInits(m mapping) [][]int {
+	var out [][]int
+	seen := make(map[string]struct{})
+	var key []byte
+	for _, info := range m {
+		for _, path := range info.init {
+			key = key[:0]
+			for _, i := range path {
+				key = strconv.AppendInt(key, int64(i), 10)
+				key = append(key, '.')
+			}
+			if _, ok := seen[string(key)]; ok {
+				continue
+			}
+			seen[string(key)] = struct{}{}
+			out = append(out, path)
+		}
+	}
+
+	return out
+}
+
 func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error)) {
+	// The mapping is fixed for the duration of the query: the field types,
+	// the validator's column names and the nested-pointer init paths are all
+	// resolved here, once, instead of once per row (per column).
+	styp := s.typ
+	if s.isPointer {
+		styp = s.typ.Elem()
+	}
+
+	ftypes := make([]reflect.Type, len(s.filtered))
+	for i, info := range s.filtered {
+		ftypes[i] = styp.FieldByIndex(info.position).Type
+	}
+
+	colNames := s.filtered.cols()
+	inits := uniqueInits(s.filtered)
+
 	return func(v *Row) (any, error) {
 			row := make([]reflect.Value, len(s.filtered))
 
 			for i, info := range s.filtered {
-				var ft reflect.Type
-				if s.isPointer {
-					ft = s.typ.Elem().FieldByIndex(info.position).Type
-				} else {
-					ft = s.typ.FieldByIndex(info.position).Type
-				}
-
 				if s.converter != nil {
-					row[i] = s.converter.TypeToDestination(ft)
+					row[i] = s.converter.TypeToDestination(ftypes[i])
 				} else {
-					row[i] = reflect.New(ft)
+					row[i] = reflect.New(ftypes[i])
 				}
 
 				v.ScheduleScanByIndexX(info.colIndex, row[i])
@@ -236,28 +272,21 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 		}, func(v any) (T, error) {
 			vals := v.([]reflect.Value)
 
-			if s.validator != nil && !s.validator(s.filtered.cols(), vals) {
+			if s.validator != nil && !s.validator(colNames, vals) {
 				var t T
 				return t, nil
 			}
 
-			var row reflect.Value
-			if s.isPointer {
-				row = reflect.New(s.typ.Elem()).Elem()
-			} else {
-				row = reflect.New(s.typ).Elem()
+			row := reflect.New(styp).Elem()
+
+			// row is freshly zero, so each unique nested pointer is
+			// initialized exactly once, ancestors before descendants
+			for _, path := range inits {
+				pv := row.FieldByIndex(path)
+				pv.Set(reflect.New(pv.Type().Elem()))
 			}
 
 			for i, info := range s.filtered {
-				for _, v := range info.init {
-					pv := row.FieldByIndex(v)
-					if !pv.IsZero() {
-						continue
-					}
-
-					pv.Set(reflect.New(pv.Type().Elem()))
-				}
-
 				var val reflect.Value
 				if s.converter != nil {
 					val = s.converter.ValueFromDestination(vals[i])

--- a/mapper_struct.go
+++ b/mapper_struct.go
@@ -186,6 +186,11 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 	}
 	inits := uniqueInits(s.filtered)
 
+	// scanOneRow calls before/scan/after strictly in sequence for each row
+	// and the mapper is built once per query, so the link holder can be
+	// reused across rows, avoiding a per-row boxing allocation.
+	link := new(rowLink)
+
 	return func(v *Row) (any, error) {
 			row := reflect.New(styp).Elem()
 
@@ -202,9 +207,11 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 				v.ScheduleScanByIndexX(info.colIndex, fv.Addr())
 			}
 
-			return row, nil
+			link.v = row
+
+			return link, nil
 		}, func(v any) (T, error) {
-			row := v.(reflect.Value)
+			row := v.(*rowLink).v
 
 			if s.isPointer {
 				row = row.Addr()
@@ -213,6 +220,10 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 			return row.Interface().(T), nil
 		}
 }
+
+// rowLink carries the in-progress row value from the before function to the
+// after function without boxing a new interface value on every row.
+type rowLink struct{ v reflect.Value }
 
 // uniqueInits collects the nested-pointer init paths of all filtered columns,
 // de-duplicated, preserving ancestor-before-descendant order.
@@ -255,20 +266,25 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 	colNames := s.filtered.cols()
 	inits := uniqueInits(s.filtered)
 
-	return func(v *Row) (any, error) {
-			row := make([]reflect.Value, len(s.filtered))
+	// scanOneRow calls before/scan/after strictly in sequence for each row
+	// and the mapper is built once per query, so the destinations slice can
+	// be reused across rows — like the links slice in [Mod] and the scan
+	// buffers in [Row]. Boxing it once also avoids a per-row allocation.
+	scratch := make([]reflect.Value, len(s.filtered))
+	var link any = scratch
 
+	return func(v *Row) (any, error) {
 			for i, info := range s.filtered {
 				if s.converter != nil {
-					row[i] = s.converter.TypeToDestination(ftypes[i])
+					scratch[i] = s.converter.TypeToDestination(ftypes[i])
 				} else {
-					row[i] = reflect.New(ftypes[i])
+					scratch[i] = reflect.New(ftypes[i])
 				}
 
-				v.ScheduleScanByIndexX(info.colIndex, row[i])
+				v.ScheduleScanByIndexX(info.colIndex, scratch[i])
 			}
 
-			return row, nil
+			return link, nil
 		}, func(v any) (T, error) {
 			vals := v.([]reflect.Value)
 

--- a/source.go
+++ b/source.go
@@ -238,6 +238,15 @@ func (s *mapperSourceImpl) setMappings(typ reflect.Type, prefix string, v visite
 }
 
 func filterColumns(c cols, m mapping, prefix string) (mapping, error) {
+	// index the mapping by name so each column is a single lookup instead of
+	// a linear search; keep the first entry per name, like the linear search did
+	byName := make(map[string]int, len(m))
+	for i, info := range m {
+		if _, ok := byName[info.name]; !ok {
+			byName[info.name] = i
+		}
+	}
+
 	// Filter the mapping so we only ask for the available columns
 	filtered := make(mapping, 0, len(c))
 	for colIdx, name := range c {
@@ -250,13 +259,11 @@ func filterColumns(c cols, m mapping, prefix string) (mapping, error) {
 			key = name[len(prefix):]
 		}
 
-		for _, info := range m {
-			if key == info.name {
-				info.name = name
-				info.colIndex = colIdx
-				filtered = append(filtered, info)
-				break
-			}
+		if i, ok := byName[key]; ok {
+			info := m[i]
+			info.name = name
+			info.colIndex = colIdx
+			filtered = append(filtered, info)
 		}
 	}
 


### PR DESCRIPTION
> Follow-up to #8 (schedule scans by column index) and #9 (reuse per-row scan buffers).

## Summary

The `Mapper` contract already states the rule this PR enforces:

> Any expensive operation, like reflection should be done outside the returned function.

The mapper factory runs once per query with the column names; the two functions it
returns run once per row. Everything that only depends on the struct type and the
column list — the "mapping plan" — is constant for the duration of the query, but the
struct mapper currently re-derives parts of it inside the per-row functions:

| re-derived per row | where | cost for 1,000 rows × 45 columns |
| --- | --- | --- |
| each destination's field type, via `reflect.Type.FieldByIndex` | `allOptions` before | 45,000 `FieldByIndex` walks, all returning the same types |
| the validator's column-name slice (`mapping.cols()` allocates) | `allOptions` after | 1,000 slices |
| the destinations slice | `allOptions` before | 1,000 slices |
| nested-pointer init checks, once per column | both paths | duplicate `IsZero` walks on a freshly zeroed struct |
| the `before`→`after` link boxing | both paths | 1,000 interface allocations |

This PR resolves the plan once, when the mapper is built, in three commits:

1. **bench**: add allOptions (TypeConverter / RowValidator) and nested-pointer
   variants of the existing wide-struct benchmarks, so each following commit can be
   measured on its own.
2. **plan**: hoist the field types, the validator's column names and the
   de-duplicated init paths out of the per-row functions; index the mapping by name
   in `filterColumns` (linear scan per column → one map lookup).
3. **buffers**: reuse the allOptions destinations slice and the `before`→`after`
   link across rows. This is the only commit that relies on the sequential
   `before`/`scan`/`after` contract, so it can be dropped or reverted independently
   if you're not comfortable with it.

## Behavior (no functional change)

- **Nested-pointer initialization is unchanged — and slightly safer.** The row
  struct starts freshly zeroed, so initializing the de-duplicated set of init paths
  unconditionally (ancestors before descendants, preserved by first-seen order over
  the per-column lists) produces exactly the state the per-column `IsZero` checks
  produced. Doing all of it *before* scheduling any field address also removes the
  possibility of re-initializing a parent after a sibling column's address was taken.
- **Buffer reuse relies only on documented sequencing.** `scanOneRow` calls
  `before`/`scan`/`after` strictly in sequence for every row (`All`, `Each`, `One`
  and `Cursor` all go through it), and the factory runs once per query — the same
  reasoning behind the `links` slice in `Mod` and the scan-destination buffers in
  `Row` (#9). `Mod` passes the inner link through untouched, so mapper mods are
  unaffected.
- **One observable edge, disclosed**: the `RowValidator` now receives the same
  column-name slice on every row instead of a fresh copy. A validator that mutates
  its `cols` argument would observe its own mutations on later rows.
- `filterColumns` keeps the first mapping entry per name, matching the previous
  linear search's `break`.

## Benchmarks

1,000 rows, pinned to one core, base/new binaries interleaved for 6 rounds
(hybrid-core laptop CPU, hence the interleaving):

```
                              sec/op          B/op        allocs/op
ScanWide45Validator          -31.99%        -29.72%        -5.98%
ScanWide45ConverterValidator -27.15%        -29.72%        -5.98%
ScanWide15NestedConverter    -39.32%        -42.38%        -9.46%
ScanWide45Converter          -26%*          -20.34%        -4.07%
ScanWide5/15/45 (regular)     ~ (no change) -0.6..-6.6%   -32.9..-33.0%
geomean                      -20.17%        -18.88%       -18.07%
```

\* p=0.065 at n=6 (the base run was noisy); the allocation numbers are exact.

No benchmark regressed. The regular path's time is unchanged (its fix is
allocation-only unless the struct has nested pointers); the allOptions path — which
is what every `TypeConverter`/`RowValidator` user pays, including bob's non-generated
`Preload` fallback — gets 25–40% faster.

## Verification

- `go test ./...` passes after each commit.
- Downstream check with bob: `go.mod` `replace`d to this branch, `go test ./orm/... .`
  and the full PostgreSQL codegen suite (`go test ./gen/bobgen-psql/...`, generated
  code exercised against a real PostgreSQL via testcontainers) pass.
- Benchmarks above; the alloc deltas match the accounting exactly (e.g. the regular
  path loses precisely 1 allocation per row — the link boxing; the validator path
  loses the per-row `cols()` slice).
