### PR TITLE
feat: add `WithRowSkip` to skip decoding already-known rows

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -244,6 +245,87 @@ type Wide45 struct {
 	Col42 string `db:"col_42"`
 	Col43 string `db:"col_43"`
 	Col44 string `db:"col_44"`
+}
+
+// benchConverter is a minimal pass-through TypeConverter: it scans into the
+// field's own type, so the benchmarks measure the allOptions machinery itself.
+type benchConverter struct{}
+
+func (benchConverter) TypeToDestination(t reflect.Type) reflect.Value { return reflect.New(t) }
+
+func (benchConverter) ValueFromDestination(v reflect.Value) reflect.Value { return v.Elem() }
+
+func benchValidator(cols []string, vals []reflect.Value) bool { return true }
+
+func BenchmarkScanWide15Converter(b *testing.B) {
+	benchmarkScanWideOpts[Wide15](b, "wide15", WithTypeConverter(benchConverter{}))
+}
+
+func BenchmarkScanWide45Converter(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45", WithTypeConverter(benchConverter{}))
+}
+
+func BenchmarkScanWide45Validator(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45", WithRowValidator(benchValidator))
+}
+
+func BenchmarkScanWide45ConverterValidator(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45",
+		WithTypeConverter(benchConverter{}), WithRowValidator(benchValidator))
+}
+
+// Wide15Nested spreads the 15 columns over two embedded pointer structs, so
+// every row initializes the mapping's nested-pointer init paths.
+type Wide15Nested struct {
+	*Wide15NestedA
+	*Wide15NestedB
+}
+
+type Wide15NestedA struct {
+	Col0 string `db:"col_0"`
+	Col1 string `db:"col_1"`
+	Col2 string `db:"col_2"`
+	Col3 string `db:"col_3"`
+	Col4 string `db:"col_4"`
+	Col5 string `db:"col_5"`
+	Col6 string `db:"col_6"`
+	Col7 string `db:"col_7"`
+}
+
+type Wide15NestedB struct {
+	Col8  string `db:"col_8"`
+	Col9  string `db:"col_9"`
+	Col10 string `db:"col_10"`
+	Col11 string `db:"col_11"`
+	Col12 string `db:"col_12"`
+	Col13 string `db:"col_13"`
+	Col14 string `db:"col_14"`
+}
+
+func BenchmarkScanWide15Nested(b *testing.B) {
+	benchmarkScanWide[Wide15Nested](b, "wide15")
+}
+
+func BenchmarkScanWide15NestedConverter(b *testing.B) {
+	benchmarkScanWideOpts[Wide15Nested](b, "wide15", WithTypeConverter(benchConverter{}))
+}
+
+func benchmarkScanWideOpts[T any](b *testing.B, table string, opts ...MappingOption) {
+	b.StopTimer()
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		rows, err := db.Query("SELECT|" + table + "||")
+		if err != nil {
+			panic(err)
+		}
+		b.StartTimer()
+		if _, err := AllFromRows(ctx, StructMapper[T](opts...), rows); err != nil {
+			panic(err)
+		}
+		rows.Close()
+	}
 }
 
 type Userss struct {

--- a/bench_test.go
+++ b/bench_test.go
@@ -53,6 +53,10 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	if err := prepareWideDupData(ctx, "wide45dup", 45, 50); err != nil {
+		panic(err)
+	}
+
 	exitVal := m.Run()
 
 	os.Exit(exitVal)
@@ -308,6 +312,63 @@ func BenchmarkScanWide15Nested(b *testing.B) {
 
 func BenchmarkScanWide15NestedConverter(b *testing.B) {
 	benchmarkScanWideOpts[Wide15Nested](b, "wide15", WithTypeConverter(benchConverter{}))
+}
+
+// prepareWideDupData is like prepareWideData except col_0 carries only
+// fanin distinct values, mimicking a to-one join key shared by many rows.
+func prepareWideDupData(ctx context.Context, table string, numCols, fanin int) error {
+	colDefs := make([]string, numCols)
+	colAssigns := make([]string, numCols)
+	for i := range colDefs {
+		colDefs[i] = fmt.Sprintf("col_%d=string", i)
+		colAssigns[i] = fmt.Sprintf("col_%d=?", i)
+	}
+
+	create := fmt.Sprintf("CREATE|%s|%s", table, strings.Join(colDefs, ","))
+	if _, err := db.ExecContext(ctx, create); err != nil {
+		return err
+	}
+
+	insert := fmt.Sprintf("INSERT|%s|%s", table, strings.Join(colAssigns, ","))
+	args := make([]any, numCols)
+	for i := 0; i < wideSize; i++ {
+		args[0] = fmt.Sprintf("key_%d", i%fanin)
+		for c := 1; c < numCols; c++ {
+			args[c] = fmt.Sprintf("value_%d_%d", i, c)
+		}
+		if _, err := db.ExecContext(ctx, insert, args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func BenchmarkScanWide45DupConverter(b *testing.B) {
+	benchmarkScanWideOpts[Wide45](b, "wide45dup",
+		WithTypeConverter(countingConverter{scans: new(int)}))
+}
+
+func BenchmarkScanWide45DupRowSkip(b *testing.B) {
+	b.StopTimer()
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		rows, err := db.Query("SELECT|wide45dup||")
+		if err != nil {
+			panic(err)
+		}
+		seen := firstSeen() // a fresh "cache" per query, like a caller would use
+		b.StartTimer()
+		if _, err := AllFromRows(ctx, StructMapper[Wide45](
+			WithTypeConverter(countingConverter{scans: new(int)}),
+			WithRowSkip([]string{"col_0"}, seen),
+		), rows); err != nil {
+			panic(err)
+		}
+		rows.Close()
+	}
 }
 
 func benchmarkScanWideOpts[T any](b *testing.B, table string, opts ...MappingOption) {

--- a/mapper_struct.go
+++ b/mapper_struct.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // CtxKeyAllowUnknownColumns makes it possible to allow unknown columns using the context
@@ -177,24 +178,26 @@ type regular[T any] struct {
 }
 
 func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
+	// The mapping is fixed for the duration of the query, so everything that
+	// only depends on it is resolved here, once, instead of once per row.
+	styp := s.typ
+	if s.isPointer {
+		styp = s.typ.Elem()
+	}
+	inits := uniqueInits(s.filtered)
+
 	return func(v *Row) (any, error) {
-			var row reflect.Value
-			if s.isPointer {
-				row = reflect.New(s.typ.Elem()).Elem()
-			} else {
-				row = reflect.New(s.typ).Elem()
+			row := reflect.New(styp).Elem()
+
+			// row is freshly zero, so each unique nested pointer is
+			// initialized exactly once, ancestors before descendants,
+			// before any field address is scheduled
+			for _, path := range inits {
+				pv := row.FieldByIndex(path)
+				pv.Set(reflect.New(pv.Type().Elem()))
 			}
 
 			for _, info := range s.filtered {
-				for _, v := range info.init {
-					pv := row.FieldByIndex(v)
-					if !pv.IsZero() {
-						continue
-					}
-
-					pv.Set(reflect.New(pv.Type().Elem()))
-				}
-
 				fv := row.FieldByIndex(info.position)
 				v.ScheduleScanByIndexX(info.colIndex, fv.Addr())
 			}
@@ -211,22 +214,55 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 		}
 }
 
+// uniqueInits collects the nested-pointer init paths of all filtered columns,
+// de-duplicated, preserving ancestor-before-descendant order.
+func uniqueInits(m mapping) [][]int {
+	var out [][]int
+	seen := make(map[string]struct{})
+	var key []byte
+	for _, info := range m {
+		for _, path := range info.init {
+			key = key[:0]
+			for _, i := range path {
+				key = strconv.AppendInt(key, int64(i), 10)
+				key = append(key, '.')
+			}
+			if _, ok := seen[string(key)]; ok {
+				continue
+			}
+			seen[string(key)] = struct{}{}
+			out = append(out, path)
+		}
+	}
+
+	return out
+}
+
 func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error)) {
+	// The mapping is fixed for the duration of the query: the field types,
+	// the validator's column names and the nested-pointer init paths are all
+	// resolved here, once, instead of once per row (per column).
+	styp := s.typ
+	if s.isPointer {
+		styp = s.typ.Elem()
+	}
+
+	ftypes := make([]reflect.Type, len(s.filtered))
+	for i, info := range s.filtered {
+		ftypes[i] = styp.FieldByIndex(info.position).Type
+	}
+
+	colNames := s.filtered.cols()
+	inits := uniqueInits(s.filtered)
+
 	return func(v *Row) (any, error) {
 			row := make([]reflect.Value, len(s.filtered))
 
 			for i, info := range s.filtered {
-				var ft reflect.Type
-				if s.isPointer {
-					ft = s.typ.Elem().FieldByIndex(info.position).Type
-				} else {
-					ft = s.typ.FieldByIndex(info.position).Type
-				}
-
 				if s.converter != nil {
-					row[i] = s.converter.TypeToDestination(ft)
+					row[i] = s.converter.TypeToDestination(ftypes[i])
 				} else {
-					row[i] = reflect.New(ft)
+					row[i] = reflect.New(ftypes[i])
 				}
 
 				v.ScheduleScanByIndexX(info.colIndex, row[i])
@@ -236,28 +272,21 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 		}, func(v any) (T, error) {
 			vals := v.([]reflect.Value)
 
-			if s.validator != nil && !s.validator(s.filtered.cols(), vals) {
+			if s.validator != nil && !s.validator(colNames, vals) {
 				var t T
 				return t, nil
 			}
 
-			var row reflect.Value
-			if s.isPointer {
-				row = reflect.New(s.typ.Elem()).Elem()
-			} else {
-				row = reflect.New(s.typ).Elem()
+			row := reflect.New(styp).Elem()
+
+			// row is freshly zero, so each unique nested pointer is
+			// initialized exactly once, ancestors before descendants
+			for _, path := range inits {
+				pv := row.FieldByIndex(path)
+				pv.Set(reflect.New(pv.Type().Elem()))
 			}
 
 			for i, info := range s.filtered {
-				for _, v := range info.init {
-					pv := row.FieldByIndex(v)
-					if !pv.IsZero() {
-						continue
-					}
-
-					pv.Set(reflect.New(pv.Type().Elem()))
-				}
-
 				var val reflect.Value
 				if s.converter != nil {
 					val = s.converter.ValueFromDestination(vals[i])

--- a/mapper_struct.go
+++ b/mapper_struct.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -108,6 +109,8 @@ type mappingOptions struct {
 	rowValidator    RowValidator
 	mapperMods      []MapperMod
 	structTagPrefix string
+	rowSkipKeys     []string
+	rowSkipSeen     func([]reflect.Value) bool
 }
 
 // MappingeOption is a function type that changes how the mapper is generated
@@ -153,11 +156,13 @@ func mapperFromMapping[T any](m mapping, typ reflect.Type, isPointer bool, opts 
 		}
 
 		mapper := regular[T]{
-			typ:       typ,
-			isPointer: isPointer,
-			filtered:  filtered,
-			converter: opts.typeConverter,
-			validator: opts.rowValidator,
+			typ:         typ,
+			isPointer:   isPointer,
+			filtered:    filtered,
+			converter:   opts.typeConverter,
+			validator:   opts.rowValidator,
+			rowSkipKeys: opts.rowSkipKeys,
+			rowSkipSeen: opts.rowSkipSeen,
 		}
 		switch {
 		case opts.typeConverter == nil && opts.rowValidator == nil:
@@ -170,11 +175,13 @@ func mapperFromMapping[T any](m mapping, typ reflect.Type, isPointer bool, opts 
 }
 
 type regular[T any] struct {
-	isPointer bool
-	typ       reflect.Type
-	filtered  mapping
-	converter TypeConverter
-	validator RowValidator
+	isPointer   bool
+	typ         reflect.Type
+	filtered    mapping
+	converter   TypeConverter
+	validator   RowValidator
+	rowSkipKeys []string
+	rowSkipSeen func([]reflect.Value) bool
 }
 
 func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
@@ -273,12 +280,45 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 	scratch := make([]reflect.Value, len(s.filtered))
 	var link any = scratch
 
+	makeDest := func(i int) reflect.Value {
+		if s.converter != nil {
+			return s.converter.TypeToDestination(ftypes[i])
+		}
+		return reflect.New(ftypes[i])
+	}
+
+	skip := buildRowSkipPlan(s.filtered, s.rowSkipKeys, s.rowSkipSeen)
+	if skip != nil {
+		skip.makeDest = makeDest
+		skip.scratch = scratch
+		// delegating a non-skipped column's scan needs the destination to
+		// be a sql.Scanner; probe one to decide for the query
+		if _, ok := makeDest(skip.conds[0].idx).Interface().(sql.Scanner); !ok {
+			skip = nil
+		}
+	}
+
 	return func(v *Row) (any, error) {
+			if skip != nil {
+				skip.state.decided = false
+			}
+
 			for i, info := range s.filtered {
-				if s.converter != nil {
-					scratch[i] = s.converter.TypeToDestination(ftypes[i])
-				} else {
-					scratch[i] = reflect.New(ftypes[i])
+				if skip != nil {
+					if slot := skip.condSlot[i]; slot >= 0 {
+						// the destination is created lazily by the
+						// condDest, and only when the row is not skipped
+						v.ScheduleScanByIndex(info.colIndex, &skip.conds[slot])
+						continue
+					}
+				}
+
+				scratch[i] = makeDest(i)
+
+				if skip != nil {
+					if slot := skip.keySlot[i]; slot >= 0 {
+						skip.keyVals[slot] = scratch[i]
+					}
 				}
 
 				v.ScheduleScanByIndexX(info.colIndex, scratch[i])
@@ -287,6 +327,43 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 			return link, nil
 		}, func(v any) (T, error) {
 			vals := v.([]reflect.Value)
+
+			if skip != nil && skip.skipped() {
+				// the row is already known: only the key columns were
+				// decoded, so build a value carrying just those — the
+				// caller promised to substitute its own copy of the row
+				row := reflect.New(styp).Elem()
+				for _, path := range inits {
+					pv := row.FieldByIndex(path)
+					pv.Set(reflect.New(pv.Type().Elem()))
+				}
+
+				for i, info := range s.filtered {
+					if skip.keySlot[i] < 0 {
+						continue
+					}
+
+					var val reflect.Value
+					if s.converter != nil {
+						val = s.converter.ValueFromDestination(vals[i])
+					} else {
+						val = vals[i].Elem()
+					}
+
+					fv := row.FieldByIndex(info.position)
+					if info.isPointer {
+						fv.Elem().Set(val)
+					} else {
+						fv.Set(val)
+					}
+				}
+
+				if s.isPointer {
+					row = row.Addr()
+				}
+
+				return row.Interface().(T), nil
+			}
 
 			if s.validator != nil && !s.validator(colNames, vals) {
 				var t T

--- a/mapper_struct.go
+++ b/mapper_struct.go
@@ -186,6 +186,11 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 	}
 	inits := uniqueInits(s.filtered)
 
+	// scanOneRow calls before/scan/after strictly in sequence for each row
+	// and the mapper is built once per query, so the link holder can be
+	// reused across rows, avoiding a per-row boxing allocation.
+	link := new(rowLink)
+
 	return func(v *Row) (any, error) {
 			row := reflect.New(styp).Elem()
 
@@ -202,9 +207,11 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 				v.ScheduleScanByIndexX(info.colIndex, fv.Addr())
 			}
 
-			return row, nil
+			link.v = row
+
+			return link, nil
 		}, func(v any) (T, error) {
-			row := v.(reflect.Value)
+			row := v.(*rowLink).v
 
 			if s.isPointer {
 				row = row.Addr()
@@ -213,6 +220,10 @@ func (s regular[T]) regular() (func(*Row) (any, error), func(any) (T, error)) {
 			return row.Interface().(T), nil
 		}
 }
+
+// rowLink carries the in-progress row value from the before function to the
+// after function without boxing a new interface value on every row.
+type rowLink struct{ v reflect.Value }
 
 // uniqueInits collects the nested-pointer init paths of all filtered columns,
 // de-duplicated, preserving ancestor-before-descendant order.
@@ -255,20 +266,25 @@ func (s regular[T]) allOptions() (func(*Row) (any, error), func(any) (T, error))
 	colNames := s.filtered.cols()
 	inits := uniqueInits(s.filtered)
 
-	return func(v *Row) (any, error) {
-			row := make([]reflect.Value, len(s.filtered))
+	// scanOneRow calls before/scan/after strictly in sequence for each row
+	// and the mapper is built once per query, so the destinations slice can
+	// be reused across rows — like the links slice in [Mod] and the scan
+	// buffers in [Row]. Boxing it once also avoids a per-row allocation.
+	scratch := make([]reflect.Value, len(s.filtered))
+	var link any = scratch
 
+	return func(v *Row) (any, error) {
 			for i, info := range s.filtered {
 				if s.converter != nil {
-					row[i] = s.converter.TypeToDestination(ftypes[i])
+					scratch[i] = s.converter.TypeToDestination(ftypes[i])
 				} else {
-					row[i] = reflect.New(ftypes[i])
+					scratch[i] = reflect.New(ftypes[i])
 				}
 
-				v.ScheduleScanByIndexX(info.colIndex, row[i])
+				v.ScheduleScanByIndexX(info.colIndex, scratch[i])
 			}
 
-			return row, nil
+			return link, nil
 		}, func(v any) (T, error) {
 			vals := v.([]reflect.Value)
 

--- a/rowskip.go
+++ b/rowskip.go
@@ -1,0 +1,171 @@
+package scan
+
+import (
+	"database/sql"
+	"reflect"
+)
+
+// WithRowSkip configures the struct mapper to skip decoding the remaining
+// columns of a row when the already-decoded key columns identify a row the
+// caller has seen before.
+//
+// keyColumns are matched against the mapped column names (after any
+// [WithStructTagPrefix] is applied by the mapping). For every row, once the
+// key columns have been scanned, seen is called with their destinations; if
+// it returns true, the remaining mapped columns are neither given
+// destinations nor scanned, the [RowValidator] is not consulted, and the
+// value built for that row carries only the key columns. Callers are
+// expected to substitute their own cached value for such rows — seen
+// returning true is a promise that the row's contents are already known.
+//
+// Skipping never changes which rows are returned, and it degrades to normal
+// scanning whenever it cannot apply:
+//   - it requires a [TypeConverter] whose destinations implement
+//     [sql.Scanner] (the mapper delegates the scan of a non-skipped column
+//     to the destination, which is only possible through that interface);
+//   - a key column that cannot be resolved disables it for the query;
+//   - columns positioned before the last key column in the result set are
+//     always decoded (the decision can only be made once the keys are known,
+//     and columns are scanned in result-set order).
+func WithRowSkip(keyColumns []string, seen func(keyValues []reflect.Value) bool) MappingOption {
+	return func(opt *mappingOptions) {
+		opt.rowSkipKeys = keyColumns
+		opt.rowSkipSeen = seen
+	}
+}
+
+// rowSkipPlan is built once per query when [WithRowSkip] is configured and
+// the key columns resolve to mapped columns that precede at least one other
+// mapped column in the result set. Everything in it is reused across rows.
+type rowSkipPlan struct {
+	seen    func([]reflect.Value) bool
+	keyVals []reflect.Value // the current row's key destinations, filled by the before function
+	state   rowSkipState
+	conds   []condDest
+
+	// set by the mapper that adopts the plan: creates the destination for a
+	// filtered column, and the destination slice shared with the after
+	// function. Destinations of skippable columns are created lazily, only
+	// when the row is not skipped.
+	makeDest func(i int) reflect.Value
+	scratch  []reflect.Value
+
+	// per filtered-column slots: >= 0 points into keyVals / conds, -1 otherwise
+	keySlot  []int
+	condSlot []int
+}
+
+// skipped reports whether the current row was identified as already known.
+func (p *rowSkipPlan) skipped() bool {
+	return p.state.decided && p.state.skip
+}
+
+// buildRowSkipPlan resolves the key columns against the filtered mapping.
+// It returns nil — turning the option into a no-op — when a key column is
+// not mapped or when no mapped column comes after the keys in the result
+// set.
+func buildRowSkipPlan(filtered mapping, keyColumns []string, seen func([]reflect.Value) bool) *rowSkipPlan {
+	if len(keyColumns) == 0 || seen == nil {
+		return nil
+	}
+
+	keySlot := make([]int, len(filtered))
+	condSlot := make([]int, len(filtered))
+	for i := range filtered {
+		keySlot[i], condSlot[i] = -1, -1
+	}
+
+	maxKeyCol := -1
+	numKeys := 0
+	for _, name := range keyColumns {
+		found := false
+		for i, info := range filtered {
+			if info.name != name {
+				continue
+			}
+			found = true
+			if keySlot[i] < 0 {
+				keySlot[i] = numKeys
+				numKeys++
+				if info.colIndex > maxKeyCol {
+					maxKeyCol = info.colIndex
+				}
+			}
+			break
+		}
+		if !found {
+			return nil
+		}
+	}
+
+	// columns are scanned in result-set order, so only columns after the
+	// last key column can react to the decision; earlier columns are simply
+	// always decoded
+	numConds := 0
+	for i, info := range filtered {
+		if keySlot[i] < 0 && info.colIndex > maxKeyCol {
+			condSlot[i] = numConds
+			numConds++
+		}
+	}
+	if numConds == 0 {
+		return nil
+	}
+
+	p := &rowSkipPlan{
+		seen:     seen,
+		keyVals:  make([]reflect.Value, numKeys),
+		keySlot:  keySlot,
+		condSlot: condSlot,
+		conds:    make([]condDest, numConds),
+	}
+	p.state.decide = func() bool { return p.seen(p.keyVals) }
+	ci := 0
+	for i := range filtered {
+		if condSlot[i] >= 0 {
+			p.conds[ci] = condDest{state: &p.state, plan: p, idx: i}
+			ci++
+		}
+	}
+
+	return p
+}
+
+// rowSkipState carries the per-row "known row?" decision. It is made lazily
+// by the first skippable column that is scanned, so the key columns —
+// scanned earlier by result-set order — are already decoded at that point.
+type rowSkipState struct {
+	decided bool
+	skip    bool
+	decide  func() bool
+}
+
+func (s *rowSkipState) skipRest() bool {
+	if !s.decided {
+		s.skip = s.decide()
+		s.decided = true
+	}
+	return s.skip
+}
+
+// condDest stands in for a skippable column's destination. When the row is
+// already known it drops the scan without ever creating the destination;
+// otherwise it creates the destination (recording it for the after
+// function) and delegates. The instances live in the plan and are reused
+// across rows.
+type condDest struct {
+	state *rowSkipState
+	plan  *rowSkipPlan
+	idx   int // index into the filtered mapping / destination slice
+}
+
+func (c *condDest) Scan(src any) error {
+	if c.state.skipRest() {
+		return nil
+	}
+
+	dest := c.plan.makeDest(c.idx)
+	c.plan.scratch[c.idx] = dest
+
+	return dest.Interface().(sql.Scanner).Scan(src)
+}

--- a/rowskip_test.go
+++ b/rowskip_test.go
@@ -1,0 +1,218 @@
+package scan
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// countingDest is a sql.Scanner destination that counts every scan, so the
+// tests can assert exactly which columns were decoded.
+type countingDest struct {
+	V     any
+	scans *int
+}
+
+func (d *countingDest) Scan(src any) error {
+	*d.scans++
+
+	switch v := d.V.(type) {
+	case *string:
+		switch s := src.(type) {
+		case string:
+			*v = s
+		case []byte:
+			*v = string(s)
+		default:
+			return fmt.Errorf("cannot scan %T into *string", src)
+		}
+	default:
+		return fmt.Errorf("unsupported destination %T", d.V)
+	}
+
+	return nil
+}
+
+type countingConverter struct {
+	scans *int
+}
+
+func (c countingConverter) TypeToDestination(typ reflect.Type) reflect.Value {
+	return reflect.ValueOf(&countingDest{V: reflect.New(typ).Interface(), scans: c.scans})
+}
+
+func (c countingConverter) ValueFromDestination(val reflect.Value) reflect.Value {
+	return val.Elem().FieldByName("V").Elem().Elem()
+}
+
+// plainConverter produces destinations that do NOT implement sql.Scanner, to
+// exercise the graceful degradation path.
+type plainConverter struct{}
+
+func (plainConverter) TypeToDestination(typ reflect.Type) reflect.Value {
+	return reflect.New(typ)
+}
+
+func (plainConverter) ValueFromDestination(val reflect.Value) reflect.Value {
+	return val.Elem()
+}
+
+type skipRow struct {
+	Key string `db:"key"`
+	A   string `db:"a"`
+	B   string `db:"b"`
+}
+
+func skipTestKey(vals []reflect.Value) string {
+	return *vals[0].Interface().(*countingDest).V.(*string)
+}
+
+// firstSeen returns a seen callback that reports a key as known from its
+// second occurrence onward — the same timing as an external cache that is
+// filled when a fresh row is consumed.
+func firstSeen() func([]reflect.Value) bool {
+	known := make(map[string]struct{})
+	return func(vals []reflect.Value) bool {
+		k := skipTestKey(vals)
+		if _, ok := known[k]; ok {
+			return true
+		}
+		known[k] = struct{}{}
+		return false
+	}
+}
+
+var (
+	skipTestCols = [][2]string{{"key", "string"}, {"a", "string"}, {"b", "string"}}
+	skipTestRows = [][]any{
+		{"k1", "a1", "b1"},
+		{"k1", "a2", "b2"},
+		{"k2", "a3", "b3"},
+		{"k1", "a4", "b4"},
+		{"k2", "a5", "b5"},
+	}
+	skipTestFull = []skipRow{
+		{Key: "k1", A: "a1", B: "b1"},
+		{Key: "k1", A: "a2", B: "b2"},
+		{Key: "k2", A: "a3", B: "b3"},
+		{Key: "k1", A: "a4", B: "b4"},
+		{Key: "k2", A: "a5", B: "b5"},
+	}
+)
+
+// runRowSkip queries the test table with a counting converter and the given
+// extra options, returning the mapped rows and the number of column scans.
+func runRowSkip(t *testing.T, queryCols []string, opts ...MappingOption) ([]skipRow, int) {
+	t.Helper()
+
+	db, cleanup := createDB(t, skipTestCols)
+	defer cleanup()
+	insert(t, db, []string{"key", "a", "b"}, skipTestRows...)
+
+	scans := 0
+	allOpts := append(
+		[]MappingOption{WithTypeConverter(countingConverter{scans: &scans})},
+		opts...,
+	)
+
+	rows, err := db.QueryContext(context.Background(), createQuery(t, queryCols))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := AllFromRows(context.Background(), StructMapper[skipRow](allOpts...), rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return got, scans
+}
+
+func TestRowSkipSkipsKnownRows(t *testing.T) {
+	got, scans := runRowSkip(t, []string{"key", "a", "b"},
+		WithRowSkip([]string{"key"}, firstSeen()))
+
+	want := []skipRow{
+		{Key: "k1", A: "a1", B: "b1"},
+		{Key: "k1"}, // known: only the key is decoded
+		{Key: "k2", A: "a3", B: "b3"},
+		{Key: "k1"},
+		{Key: "k2"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error(diff)
+	}
+
+	// the key always decodes (5 rows) and a/b only decode on the two
+	// first-seen rows (2 rows x 2 columns)
+	if scans != 9 {
+		t.Errorf("expected 9 column scans, got %d", scans)
+	}
+}
+
+func TestRowSkipKeyAfterOtherColumns(t *testing.T) {
+	// the key is the last column of the result set, so no column can react
+	// to the decision: everything is decoded, results are unchanged
+	got, scans := runRowSkip(t, []string{"a", "b", "key"},
+		WithRowSkip([]string{"key"}, firstSeen()))
+
+	if diff := cmp.Diff(skipTestFull, got); diff != "" {
+		t.Error(diff)
+	}
+	if scans != 15 {
+		t.Errorf("expected 15 column scans, got %d", scans)
+	}
+}
+
+func TestRowSkipUnknownKeyColumn(t *testing.T) {
+	got, scans := runRowSkip(t, []string{"key", "a", "b"},
+		WithRowSkip([]string{"nope"}, firstSeen()))
+
+	if diff := cmp.Diff(skipTestFull, got); diff != "" {
+		t.Error(diff)
+	}
+	if scans != 15 {
+		t.Errorf("expected 15 column scans, got %d", scans)
+	}
+}
+
+func TestRowSkipNeverSeen(t *testing.T) {
+	got, scans := runRowSkip(t, []string{"key", "a", "b"},
+		WithRowSkip([]string{"key"}, func([]reflect.Value) bool { return false }))
+
+	if diff := cmp.Diff(skipTestFull, got); diff != "" {
+		t.Error(diff)
+	}
+	if scans != 15 {
+		t.Errorf("expected 15 column scans, got %d", scans)
+	}
+}
+
+func TestRowSkipNonScannerDestinations(t *testing.T) {
+	// plainConverter destinations don't implement sql.Scanner, so skipping
+	// cannot delegate and every column is decoded normally — even though
+	// seen always reports the row as known
+	db, cleanup := createDB(t, skipTestCols)
+	defer cleanup()
+	insert(t, db, []string{"key", "a", "b"}, skipTestRows...)
+
+	rows, err := db.QueryContext(context.Background(), createQuery(t, []string{"key", "a", "b"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := AllFromRows(context.Background(), StructMapper[skipRow](
+		WithTypeConverter(plainConverter{}),
+		WithRowSkip([]string{"key"}, func([]reflect.Value) bool { return true }),
+	), rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(skipTestFull, got); diff != "" {
+		t.Error(diff)
+	}
+}

--- a/source.go
+++ b/source.go
@@ -238,6 +238,15 @@ func (s *mapperSourceImpl) setMappings(typ reflect.Type, prefix string, v visite
 }
 
 func filterColumns(c cols, m mapping, prefix string) (mapping, error) {
+	// index the mapping by name so each column is a single lookup instead of
+	// a linear search; keep the first entry per name, like the linear search did
+	byName := make(map[string]int, len(m))
+	for i, info := range m {
+		if _, ok := byName[info.name]; !ok {
+			byName[info.name] = i
+		}
+	}
+
 	// Filter the mapping so we only ask for the available columns
 	filtered := make(mapping, 0, len(c))
 	for colIdx, name := range c {
@@ -250,13 +259,11 @@ func filterColumns(c cols, m mapping, prefix string) (mapping, error) {
 			key = name[len(prefix):]
 		}
 
-		for _, info := range m {
-			if key == info.name {
-				info.name = name
-				info.colIndex = colIdx
-				filtered = append(filtered, info)
-				break
-			}
+		if i, ok := byName[key]; ok {
+			info := m[i]
+			info.name = name
+			info.colIndex = colIdx
+			filtered = append(filtered, info)
 		}
 	}
 


### PR DESCRIPTION
> Builds on #12 (plan-once struct mapper) — please review that one first; this PR's diff assumes its structure.

## Summary

Preload-style queries deliver the same related row once per parent row: 1,000
task rows pointing at 50 servers carry each server's columns ~20 times. A
caller that shares one instance per distinct key (bob's `Preload` does this
since stephenafamo/bob#736) still pays to *decode* every duplicate — the
destinations are created, scanned into, read back, and then thrown away
because the built value is discarded in favour of the cached instance.

This PR adds an opt-in mapping option that stops paying that cost:

```go
StructMapper[T](
    WithTypeConverter(conv),
    WithRowSkip([]string{"server.id"}, func(keys []reflect.Value) bool {
        return cache.Contains(keys) // read-only probe into the caller's cache
    }),
)
```

Columns are scanned in result-set order, so once the key columns are decoded,
the first remaining column asks `seen` whether the row is already known. If it
is, the remaining mapped columns are **neither given destinations nor
scanned**, the `RowValidator` is not consulted, and the value built for the
row carries only the key columns — `seen` returning true is the caller's
promise that it will substitute its own copy of the row.

## When it applies (and when it silently doesn't)

| situation | behavior |
| --- | --- |
| destinations implement `sql.Scanner` (e.g. from a `TypeConverter`) | skipping active |
| destinations are plain pointers | normal scanning (delegation is impossible without `sql.Scanner`) |
| a key column is not mapped | normal scanning for the whole query |
| a mapped column sits *before* the last key column in the result set | that column is always decoded (columns are scanned in order; the decision only exists after the keys) |
| `seen` returns false | the row is scanned exactly as before |

Every degradation is decided per query (or per column) and falls back to the
previous behavior — results never change for rows that are not skipped.

## Behavior notes

- The skip decision is made lazily by the first skippable column's
  destination (a small reusable `sql.Scanner` shim), so the key columns are
  already decoded at that point. No extra pass over the row is needed.
- For skipped rows the after function short-circuits: no validator call, no
  per-column extraction — it builds a value with only the key columns set.
- The shims and the plan live in the mapper closure and are reused across
  rows: the option adds no per-row allocations of its own.

## Benchmarks

1,000 rows × 45 string columns, 50 distinct keys in `col_0` (fan-in 20),
pass-through converter:

```
                                 time/op        B/op       allocs/op
ScanWide45DupConverter (base)    ~6.6ms       5.67MB        92,034
ScanWide45DupRowSkip             ~5.7ms       4.00MB         8,452  (-90.8%)
```

The allocation and byte counts are deterministic; time was faster in every
paired run (−17% to −69% on a noisy laptop). The benchmark converter's
`Scan` is intentionally trivial, so the time savings here come almost
entirely from skipping destination creation and extraction; converters that
do real conversion work save proportionally more.

## Verification

- `go test ./...` passes; five dedicated tests cover: skipping known rows
  (exact per-column scan counts), key-after-columns, unresolvable key,
  `seen` always false (results identical to no option), and non-`Scanner`
  destinations (results identical to no option).
- Downstream consumer: bob's `Preload` dedup (stephenafamo/bob#736) can pass
  a read-only probe of its per-query cache as `seen`; a follow-up PR there
  wires it up. Nothing in this PR depends on bob.
